### PR TITLE
feat(HyperRequest): Add throw on error flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,31 @@ Check if the request has a query parameter with the given name.
 | ---- | ------ | -------- | ------- | ----------------------------------------- |
 | name | string | true     |         | The name of the query parameter to check. |
 
+##### `setThrowOnError`
+
+Sets the throw on error property for the request. If true, error codes and status
+will be turned in to exceptions.
+
+| Name | Type   | Required | Default | Description                               |
+| ---- | ------ | -------- | ------- | ----------------------------------------- |
+| value | boolean | true     |         | The value of the throw on error flag. |
+
+##### `throwErrors`
+
+A convenience method to throw on errors.
+
+| Name         | Type | Required | Default | Description |
+| ------------ | ---- | -------- | ------- | ----------- |
+| No arguments |      |          |         |             |
+
+##### `allowErrors`
+
+A convenience method to not throw on errors.
+
+| Name         | Type | Required | Default | Description |
+| ------------ | ---- | -------- | ------- | ----------- |
+| No arguments |      |          |         |             |
+
 ##### `setProperties`
 
 Quickly set many request properties using a struct. The key should be the name

--- a/models/HyperRequest.cfc
+++ b/models/HyperRequest.cfc
@@ -72,6 +72,11 @@ component accessors="true" {
     property name="queryParams";
 
     /**
+    * Flag to throw on a cfhttp error.
+    */
+    property name="throwOnError" default="false";
+
+    /**
     * Initialize a new HyperRequest.
     *
     * @returns The HyperRequest instance.
@@ -333,6 +338,26 @@ component accessors="true" {
     }
 
     /**
+    * A convenience method to not throw on errors.
+    *
+    * @returns The HyperRequest instance.
+    */
+    function allowErrors() {
+        setThrowOnError( false );
+        return this;
+    }
+
+    /**
+    * A convenience method to throw on errors.
+    *
+    * @returns The HyperRequest instance.
+    */
+    function throwErrors() {
+        setThrowOnError( true );
+        return this;
+    }
+
+    /**
     * A convenience method to set the body format and Content-Type to json.
     *
     * @returns The HyperRequest instance.
@@ -557,7 +582,8 @@ component accessors="true" {
             method = getMethod(),
             redirect = false,
             username = getUsername(),
-            password = getPassword()
+            password = getPassword(),
+            throwonerror = getThrowOnError()
         ) {
             for ( var name in variables.headers ) {
                 cfhttpparam(


### PR DESCRIPTION
Throw on error is passed along to the `cfhttp` request.

Additionally, two helper methods are defined:
1. `throwErrors` — sets the `throwOnError` flag to `true`
1. `ignoreErrors` — sets the `throwOnError` flag to `false`

The default value of the flag is `false` to maintain backward compatibility.