### PR TITLE
feat(HttpClient): Allow for pluggable HTTP Clients

### DIFF
--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -3,18 +3,7 @@ component {
     this.name = "hyper";
     this.author = "";
     this.webUrl = "https://github.com/elpete/hyper";
-    this.autoMapModels = false;
     this.cfmapping = "hyper";
 
-    function configure() {
-        binder.map( "HyperBuilder@hyper" )
-            .to( "#moduleMapping#.models.HyperBuilder" )
-            .asSingleton();
-
-        binder.map( "HyperRequest@hyper" )
-            .to( "#moduleMapping#.models.HyperRequest" );
-
-        binder.map( "HyperResponse@hyper" )
-            .to( "#moduleMapping#.models.HyperResponse" );
-    }
+    function configure() {}
 }

--- a/models/CfhttpHttpClient.cfc
+++ b/models/CfhttpHttpClient.cfc
@@ -1,0 +1,105 @@
+/**
+ * Uses CFHTTP to execute HyperRequests.
+ */
+component implements="HyperHttpClientInterface" {
+
+    /**
+     * Execute the HyperRequest and map it to a HyperResponse.
+     *
+     * @req     The HyperRequest to execute.
+     *
+     * @returns A HyperResponse of the executed request.
+     */
+    public HyperResponse function send( required HyperRequest req ) {
+        var cfhttpResponse = makeCFHTTPRequest( req );
+        return new Hyper.models.HyperResponse(
+            originalRequest = req,
+            charset = cfhttpResponse.charset ?: "UTF-8",
+            statusCode = cfhttpResponse.responseheader.status_code ?: 504,
+            headers = normalizeHeaders( cfhttpResponse ),
+            data = cfhttpResponse.filecontent
+        );
+    }
+
+    /**
+     * Makes an HTTP request using CFHTTP.
+     *
+     * @req     The request to execute
+     *
+     * @returns The CFHTTP response struct.
+     */
+    private struct function makeCFHTTPRequest( required HyperRequest req ) {
+        local.res = "";
+        var attrCollection = {
+            result = "local.res",
+            timeout = req.getTimeout(),
+            url = req.getFullUrl(),
+            method = req.getMethod(),
+            redirect = false,
+            throwonerror = req.getThrowOnError()
+        };
+
+        if ( len( req.getUsername() ) ) {
+            attrCollection[ "username" ] = req.getUsername();
+        }
+        if ( len( req.getPassword() ) ) {
+            attrCollection[ "password" ] = req.getPassword();
+        }
+
+        cfhttp( attributeCollection = attrCollection ) {
+            var headers = req.getHeaders();
+            for ( var name in headers ) {
+                cfhttpparam(
+                    type = "header",
+                    name = name,
+                    value = headers[ name ]
+                );
+            }
+
+            var queryParams = req.getQueryParams();
+            for ( var name in queryParams ) {
+                cfhttpparam(
+                    type = "url",
+                    name = name,
+                    value = queryParams[ name ]
+                );
+            }
+
+            if ( req.hasBody() ) {
+                if ( req.getBodyFormat() == "json" ) {
+                    cfhttpparam( type = "body", value = req.prepareBody() );
+                }
+                else if ( req.getBodyFormat() == "formFields" ) {
+                    var body = req.getBody();
+                    for ( var fieldName in body ) {
+                        cfhttpparam(
+                            type  = "formfield",
+                            name  = fieldName,
+                            value = body[ fieldName ]
+                        );
+                    }
+                }
+                else {
+                    cfhttpparam( type = "body", value = req.prepareBody() );
+                }
+            }
+        }
+        return local.res;
+    }
+
+    /**
+     * Normalizes the headers from a CFHTTP response into a normalized struct.
+     *
+     * @cfhttpResponse The cfhttp response struct.
+     *
+     * @returns        A struct of normalized headers.
+     */
+    private struct function normalizeHeaders( required struct cfhttpResponse ) {
+        var headers = {};
+        cfhttpResponse.responseheader.each( function( name, value ) {
+            headers[ lcase( name ) ] = value;
+        } );
+        return headers;
+    }
+
+}

--- a/models/HyperBuilder.cfc
+++ b/models/HyperBuilder.cfc
@@ -1,7 +1,7 @@
 /**
 * Creates new requests with optional defaults.
 */
-component {
+component singleton {
 
     /**
     * The default request object.

--- a/models/HyperHttpClientInterface.cfc
+++ b/models/HyperHttpClientInterface.cfc
@@ -1,0 +1,15 @@
+/**
+ * Responsible for executing the HyperRequest and mapping it to a HyperResponse
+ */
+interface displayname="HyperHttpClientInterface" {
+
+    /**
+     * Execute the HyperRequest and map it to a HyperResponse.
+     *
+     * @req     The HyperRequest to execute.
+     *
+     * @returns A HyperResponse of the executed request.
+     */
+    public HyperResponse function send( required HyperRequest req );
+
+}

--- a/models/HyperResponse.cfc
+++ b/models/HyperResponse.cfc
@@ -21,7 +21,12 @@ component accessors="true" {
     /**
      * The charset value for the response.
      */
-    property name="charset" setter="false";
+    property name="charset" default="UTF-8" setter="false";
+
+    /**
+     * The charset value for the response.
+     */
+    property name="headers" type="struct" setter="false";
 
     /**
      * The timestamp for when this response was received.
@@ -36,16 +41,28 @@ component accessors="true" {
     /**
      * Create a new HyperResponse.
      *
-     * @req            The HyperRequest associated with this response.
-     * @cfhttpResponse The CFHTTP response struct.
-     * @timestamp      The timestamp for when this response was received.
-     *                 Default: `now()`.
+     * @originalRequest The HyperRequest associated with this response.
+     * @charset         The response charset. Default: UTF-8
+     * @statusCode      The response status code. Default: 200.
+     * @headers         The response headers. Default: {}.
+     * @data            The response data. Default: "".
+     * @timestamp       The timestamp for when this response was received. Default: `now()`.
      *
-     * @returns        A new HyperResponse instance.
+     * @returns         A new HyperResponse instance.
      */
-    function init( req, cfhttpResponse, timestamp = now() ) {
-        variables.request = req;
-        populateFromCFHTTP( cfhttpResponse );
+    public HyperResponse function init(
+        required HyperRequest originalRequest,
+        string charset = "UTF-8",
+        any statusCode = 200,
+        struct headers = {},
+        any data = "",
+        timestamp = now()
+    ) {
+        variables.request = arguments.originalRequest;
+        variables.charset = arguments.charset;
+        variables.statusCode = arguments.statusCode;
+        variables.headers = arguments.headers;
+        variables.data = arguments.data;
         variables.timestamp = arguments.timestamp;
         return this;
     }
@@ -99,22 +116,6 @@ component accessors="true" {
      */
     function isServerError() {
         return left( getStatusCode(), 1 ) == "5";
-    }
-
-    /**
-     * Populates the HyperResponse values from a CFHTTP struct.
-     *
-     * @res The CFHTTP struct.
-     */
-    private function populateFromCFHTTP( res ) {
-        variables.charset =  res.charset ?: "UTF-8";
-        variables.statusCode = res.responseheader.status_code ?: 504;
-        res.responseheader.each( function( name, value ) {
-            variables.headers[ lcase( name ) ] = value;
-        } );
-        variables.data = res.filecontent;
-
-        return this;
     }
 
     /**

--- a/tests/specs/unit/HyperResponseSpec.cfc
+++ b/tests/specs/unit/HyperResponseSpec.cfc
@@ -3,13 +3,15 @@ component extends="testbox.system.BaseSpec" {
     function run() {
         describe( "HyperResponse", function() {
             it( "throws an exception when requesting json data but the data is not json", function() {
-                var res = new Hyper.models.HyperResponse( createStub(), {
-                    "charset" = "UTF-8",
-                    "responseheader" = {
+                var res = new Hyper.models.HyperResponse(
+                    originalRequest = createStub( extends = "models.HyperRequest" ),
+                    charset = "UTF-8",
+                    statusCode = 200,
+                    headers = {
                         "status_code" = "200"
                     },
-                    "filecontent" = "definitely not json"
-                } );
+                    data = "definitely not json"
+                );
                 expect( function() {
                     var json = res.json();
                 } ).toThrow( "DeserializeJsonException" );
@@ -17,13 +19,10 @@ component extends="testbox.system.BaseSpec" {
 
             describe( "status code detection", function() {
                 it( "can tell if a request is a success", function() {
-                    var res = new Hyper.models.HyperResponse( createStub(), {
-                        "charset" = "UTF-8",
-                        "responseheader" = {
-                            "status_code" = "200"
-                        },
-                        "filecontent" = ""
-                    } );
+                    var res = new Hyper.models.HyperResponse(
+                        originalRequest = createStub( extends = "models.HyperRequest" ),
+                        statusCode = 200
+                    );
                     expect( res.isSuccess() ).toBeTrue();
                     expect( res.isRedirect() ).toBeFalse();
                     expect( res.isError() ).toBeFalse();
@@ -32,13 +31,10 @@ component extends="testbox.system.BaseSpec" {
                 } );
 
                 it( "can tell if a request is a redirect", function() {
-                    var res = new Hyper.models.HyperResponse( createStub(), {
-                        "charset" = "UTF-8",
-                        "responseheader" = {
-                            "status_code" = "302"
-                        },
-                        "filecontent" = ""
-                    } );
+                    var res = new Hyper.models.HyperResponse(
+                        originalRequest = createStub( extends = "models.HyperRequest" ),
+                        statusCode = 302
+                    );
                     expect( res.isSuccess() ).toBeFalse();
                     expect( res.isRedirect() ).toBeTrue();
                     expect( res.isError() ).toBeFalse();
@@ -47,13 +43,10 @@ component extends="testbox.system.BaseSpec" {
                 } );
 
                 it( "can tell if a request is a client error", function() {
-                    var res = new Hyper.models.HyperResponse( createStub(), {
-                        "charset" = "UTF-8",
-                        "responseheader" = {
-                            "status_code" = "422"
-                        },
-                        "filecontent" = ""
-                    } );
+                    var res = new Hyper.models.HyperResponse(
+                        originalRequest = createStub( extends = "models.HyperRequest" ),
+                        statusCode = 422
+                    );
                     expect( res.isSuccess() ).toBeFalse();
                     expect( res.isRedirect() ).toBeFalse();
                     expect( res.isError() ).toBeTrue();
@@ -62,13 +55,10 @@ component extends="testbox.system.BaseSpec" {
                 } );
 
                 it( "can tell if a request is a server error", function() {
-                    var res = new Hyper.models.HyperResponse( createStub(), {
-                        "charset" = "UTF-8",
-                        "responseheader" = {
-                            "status_code" = "500"
-                        },
-                        "filecontent" = ""
-                    } );
+                    var res = new Hyper.models.HyperResponse(
+                        originalRequest = createStub( extends = "models.HyperRequest" ),
+                        statusCode = 500
+                    );
                     expect( res.isSuccess() ).toBeFalse();
                     expect( res.isRedirect() ).toBeFalse();
                     expect( res.isError() ).toBeTrue();


### PR DESCRIPTION
HTTP Clients can be set on each request using the `httpClient` property
or as a builder default.  By default the `CfhttpHttpClient` is used, which
is how Hyper has operated up to this point.  Now other clients can
be created, such as an Apache Http Components Client.  These
clients make perfect sense as modules. Users can create custom builders
that use the can be configured during `afterConfigurationLoad` interception point.