### PR TITLE
Support WireBox without ColdBox

### DIFF
--- a/models/HyperBuilder.cfc
+++ b/models/HyperBuilder.cfc
@@ -24,7 +24,9 @@ component singleton {
 	}
 
 	function onDIComplete() {
-		this.defaults.setInterceptorService( variables.interceptorService );
+		if ( structKeyExists( variables, "interceptorService" ) ) {
+			this.defaults.setInterceptorService( variables.interceptorService );
+		}
 	}
 
 	/**


### PR DESCRIPTION
When you use WireBox standalone then `onDIComplete` is called but `box:interceptorService` injection doesn't exist so it
errors. This change means that you can use WireBox standalone with Hyper by checking if the `interceptorService`
dependency exists.