### PR TITLE
feat(async): Add async requests using ColdBox's AsyncManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,27 @@ Execute a GET request.
 | url         | string | false    | null    | An optional URL to set for the request.                        |
 | queryParams | struct | false    | null    | An optional struct of query parameters to set for the request. |
 
+##### `getAsync`
+
+Execute a GET request asynchronously. Returns a ColdBox Future that returns a HyperResponse.
+
+| Name        | Type   | Required | Default | Description                                                    |
+| ----------- | ------ | -------- | ------- | -------------------------------------------------------------- |
+| url         | string | false    | null    | An optional URL to set for the request.                        |
+| queryParams | struct | false    | null    | An optional struct of query parameters to set for the request. |
+
 ##### `post`
 
 Execute a POST request.
+
+| Name | Type   | Required | Default | Description                              |
+| ---- | ------ | -------- | ------- | ---------------------------------------- |
+| url  | string | false    | null    | An optional URL to set for the request.  |
+| body | struct | false    | null    | An optional body to set for the request. |
+
+##### `postAsync`
+
+Execute a POST request asynchronously. Returns a ColdBox Future that returns a HyperResponse.
 
 | Name | Type   | Required | Default | Description                              |
 | ---- | ------ | -------- | ------- | ---------------------------------------- |
@@ -107,9 +125,27 @@ Execute a PUT request.
 | url  | string | false    | null    | An optional URL to set for the request.  |
 | body | struct | false    | null    | An optional body to set for the request. |
 
+##### `putAsync`
+
+Execute a PUT request asynchronously. Returns a ColdBox Future that returns a HyperResponse.
+
+| Name | Type   | Required | Default | Description                              |
+| ---- | ------ | -------- | ------- | ---------------------------------------- |
+| url  | string | false    | null    | An optional URL to set for the request.  |
+| body | struct | false    | null    | An optional body to set for the request. |
+
 ##### `patch`
 
 Execute a PATCH request.
+
+| Name | Type   | Required | Default | Description                              |
+| ---- | ------ | -------- | ------- | ---------------------------------------- |
+| url  | string | false    | null    | An optional URL to set for the request.  |
+| body | struct | false    | null    | An optional body to set for the request. |
+
+##### `patchAsync`
+
+Execute a PATCH request asynchronously. Returns a ColdBox Future that returns a HyperResponse.
 
 | Name | Type   | Required | Default | Description                              |
 | ---- | ------ | -------- | ------- | ---------------------------------------- |
@@ -125,9 +161,26 @@ Execute a DELETE request.
 | url  | string | false    | null    | An optional URL to set for the request.  |
 | body | struct | false    | null    | An optional body to set for the request. |
 
+##### `deleteAsync`
+
+Execute a DELETE request asynchronously. Returns a ColdBox Future that returns a HyperResponse.
+
+| Name | Type   | Required | Default | Description                              |
+| ---- | ------ | -------- | ------- | ---------------------------------------- |
+| url  | string | false    | null    | An optional URL to set for the request.  |
+| body | struct | false    | null    | An optional body to set for the request. |
+
 ##### `send`
 
 Send the HTTP request and return a HyperResponse.
+
+| Name         | Type | Required | Default | Description |
+| ------------ | ---- | -------- | ------- | ----------- |
+| No arguments |      |          |         |             |
+
+##### `sendAsync`
+
+Send the HTTP request asynchronously and return a ColdBox Future that will resolve to a HyperResponse.
 
 | Name         | Type | Required | Default | Description |
 | ------------ | ---- | -------- | ------- | ----------- |
@@ -368,7 +421,8 @@ Gets the body format for the request.
 
 ##### `setBodyFormat`
 
-Sets the body format for the request.
+Sets the body format for the request. Allowed values are either `formFields` or `json`.
+It is highly receommended to use `asFormFields` or `asJson` instead.
 
 | Name  | Type | Required | Default | Description                      |
 | ----- | ---- | -------- | ------- | -------------------------------- |
@@ -579,6 +633,15 @@ A noop option is provided in the `init` for non-ColdBox settings.
 | Name         | Type | Required | Default | Description |
 | ------------ | ---- | -------- | ------- | ----------- |
 | interceptorService   | any    | `true`          |         | The interceptor service to use for the request.             |
+
+##### `setAsyncManager`
+
+ColdBox AsyncManager to send requests asynchronously.
+A noop option is provided in the `init` for non-ColdBox settings.
+
+| Name         | Type | Required | Default | Description |
+| ------------ | ---- | -------- | ------- | ----------- |
+| asyncManager   | any    | `true`          |         | The asyncManager to use for the request.             |
 
 ### HyperResponse
 

--- a/models/HyperBuilder.cfc
+++ b/models/HyperBuilder.cfc
@@ -4,6 +4,7 @@
 component singleton {
 
 	property name="interceptorService" inject="box:interceptorService";
+	property name="asyncManager"       inject="box:asyncManager";
 
 	/**
 	 * Create a new HyperBuilder.
@@ -26,6 +27,10 @@ component singleton {
 	function onDIComplete() {
 		if ( structKeyExists( variables, "interceptorService" ) ) {
 			this.defaults.setInterceptorService( variables.interceptorService );
+		}
+
+		if ( structKeyExists( variables, "asyncManager" ) ) {
+			this.defaults.setAsyncManager( variables.asyncManager );
 		}
 	}
 

--- a/models/HyperRequest.cfc
+++ b/models/HyperRequest.cfc
@@ -14,6 +14,11 @@ component accessors="true" {
 	property name="interceptorService";
 
 	/**
+	 * ColdBox Interceptor Service to announce request and response interception points.
+	 */
+	property name="asyncManager";
+
+	/**
 	 * The httpClient to use for the request.
 	 */
 	property name="httpClient";
@@ -163,6 +168,11 @@ component accessors="true" {
 			"processState" : function() {
 			}
 		};
+		variables.asyncManager = {
+			"newFuture" : function() {
+				throw( "No asyncManager set!" );
+			}
+		};
 		return this;
 	}
 
@@ -183,6 +193,25 @@ component accessors="true" {
 		}
 		setMethod( "GET" );
 		return send();
+	}
+
+	/**
+	 * Execute a GET request asynchronously.
+	 *
+	 * @url         An optional url to set for the request.
+	 * @queryParams An optional struct of query parameters to set for the request.
+	 *
+	 * @returns     A ColdBox Future instance.
+	 */
+	function getAsync( url, queryParams ) {
+		if ( !isNull( arguments.url ) ) {
+			setUrl( arguments.url );
+		}
+		if ( !isNull( arguments.queryParams ) ) {
+			setQueryParams( arguments.queryParams );
+		}
+		setMethod( "GET" );
+		return sendAsync();
 	}
 
 	/**
@@ -207,6 +236,27 @@ component accessors="true" {
 	}
 
 	/**
+	 * Execute a POST request asynchronously.
+	 *
+	 * @url     An optional url to set for the request.
+	 * @body    An optional body to set for the request.
+	 *
+	 * @returns A ColdBox Future instance.
+	 */
+	function postAsync( url, body ) {
+		if ( !isNull( arguments.url ) ) {
+			setUrl( arguments.url );
+		}
+
+		if ( !isNull( arguments.body ) ) {
+			setBody( arguments.body );
+		}
+
+		setMethod( "POST" );
+		return sendAsync();
+	}
+
+	/**
 	 * Execute a PUT request.
 	 *
 	 * @url     An optional url to set for the request.
@@ -225,6 +275,27 @@ component accessors="true" {
 
 		setMethod( "PUT" );
 		return send();
+	}
+
+	/**
+	 * Execute a PUT request asynchronously.
+	 *
+	 * @url     An optional url to set for the request.
+	 * @body    An optional body to set for the request.
+	 *
+	 * @returns A ColdBox Future instance.
+	 */
+	function putAsync( url, body ) {
+		if ( !isNull( arguments.url ) ) {
+			setUrl( arguments.url );
+		}
+
+		if ( !isNull( arguments.body ) ) {
+			setBody( arguments.body );
+		}
+
+		setMethod( "PUT" );
+		return sendAsync();
 	}
 
 	/**
@@ -249,6 +320,27 @@ component accessors="true" {
 	}
 
 	/**
+	 * Execute a PATCH request asynchronously.
+	 *
+	 * @url     An optional url to set for the request.
+	 * @body    An optional body to set for the request.
+	 *
+	 * @returns A ColdBox Future instance.
+	 */
+	function patchAsync( url, body ) {
+		if ( !isNull( arguments.url ) ) {
+			setUrl( arguments.url );
+		}
+
+		if ( !isNull( arguments.body ) ) {
+			setBody( arguments.body );
+		}
+
+		setMethod( "PATCH" );
+		return sendAsync();
+	}
+
+	/**
 	 * Execute a DELETE request.
 	 *
 	 * @url     An optional url to set for the request.
@@ -267,6 +359,27 @@ component accessors="true" {
 
 		setMethod( "DELETE" );
 		return send();
+	}
+
+	/**
+	 * Execute a DELETE request asynchronously.
+	 *
+	 * @url     An optional url to set for the request.
+	 * @body    An optional body to set for the request.
+	 *
+	 * @returns A ColdBox Future instance.
+	 */
+	function deleteAsync( url, body ) {
+		if ( !isNull( arguments.url ) ) {
+			setUrl( arguments.url );
+		}
+
+		if ( !isNull( arguments.body ) ) {
+			setBody( arguments.body );
+		}
+
+		setMethod( "DELETE" );
+		return sendAsync();
 	}
 
 	/**
@@ -632,6 +745,16 @@ component accessors="true" {
 		return this;
 	}
 
+	function sendAsync() {
+		if ( isNull( variables.asyncManager ) ) {
+			throw( "No asyncManager set!" );
+		}
+
+		return variables.asyncManager.newFuture( function() {
+			return this.send();
+		} );
+	}
+
 	/**
 	 * Send the HTTP request and return a HyperResponse.
 	 *
@@ -724,6 +847,7 @@ component accessors="true" {
 	public HyperRequest function clone() {
 		var req = new HyperRequest();
 		req.setInterceptorService( variables.interceptorService );
+		req.setAsyncManager( variables.asyncManager );
 		req.setHttpClient( variables.httpClient );
 		req.setBaseUrl( variables.baseUrl );
 		req.setUrl( variables.url );

--- a/tests/specs/integration/AsyncSpec.cfc
+++ b/tests/specs/integration/AsyncSpec.cfc
@@ -1,0 +1,73 @@
+component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
+
+	function beforeAll() {
+		super.beforeAll();
+		variables.hyper        = getInstance( "HyperBuilder@hyper" );
+		variables.asyncManager = getInstance( "box:asyncManager" );
+	}
+
+	function run() {
+		describe( "async requests", function() {
+			it( "can send a request asynchronously", function() {
+				var future = hyper.setUrl( "https://jsonplaceholder.typicode.com/posts/1" ).sendAsync();
+				expect( future ).toBeInstanceOf( "Future", "A Future object should have been returned." );
+				var res = future.get();
+				expect( future.isDone() ).toBeTrue( "Future should be completed." );
+				expect( res ).toBeInstanceOf( "HyperResponse", "A HyperResponse object should have been returned." );
+				var data = res.json();
+				expect( data ).toBeStruct( "Expected to deserialize JSON data from the response." );
+				expect( data ).toBe(
+					deserializeJSON(
+						"{
+                        ""userId"": 1,
+                        ""id""    : 1,
+                        ""title"" : ""sunt aut facere repellat provident occaecati excepturi optio reprehenderit"",
+                        ""body""  : ""quia et suscipit\nsuscipit recusandae consequuntur expedita et cum\nreprehenderit molestiae ut ut quas totam\nnostrum rerum est autem sunt rem eveniet architecto""
+                    }"
+					)
+				);
+			} );
+
+			it( "can send requests asynchronously without joining", function() {
+				var requestFinished = false;
+				hyper
+					.setUrl( "https://jsonplaceholder.typicode.com/posts/1" )
+					.sendAsync()
+					.then( function( res ) {
+						requestFinished = true;
+					} );
+
+				for ( var i = 0; i <= 3000; i += 100 ) {
+					if ( requestFinished ) {
+						return;
+					}
+					sleep( 100 );
+				}
+
+				fail( "Request did not finish after 3000ms. Aborting." );
+			} );
+
+			it( "can send multiple async requests", function() {
+				var allFuture = variables.asyncManager.all( [
+					hyper.getAsync( "https://jsonplaceholder.typicode.com/posts/1" ),
+					hyper.getAsync( "https://jsonplaceholder.typicode.com/posts/2" ),
+					hyper.getAsync( "https://jsonplaceholder.typicode.com/posts/3" )
+				] );
+
+				expect( allFuture ).toBeInstanceOf( "Future", "A Future object should have been returned." );
+				var responseArray = allFuture.get();
+				expect( responseArray ).toBeArray();
+				expect( responseArray ).toHaveLength( 3 );
+
+				for ( var i = 1; i <= responseArray.len(); i++ ) {
+					var res = responseArray[ i ];
+					expect( res ).toBeInstanceOf( "HyperResponse", "A HyperResponse object should have been returned." );
+					var data = res.json();
+					expect( data ).toBeStruct( "Expected to deserialize JSON data from the response." );
+					expect( data.id ).toBe( i );
+				}
+			} );
+		} );
+	}
+
+}


### PR DESCRIPTION
This PR adds the ability to easily send `HyperRequest`s asynchronously using ColdBox's `AsyncManager`.

It is additive and does not impact the ability to send requests normally, with or without ColdBox.

If trying to send requests asynchronously in a non-ColdBox setting the user must either wire up their own `asyncManager` and pass it to their `HyperBuilder` or an exception will be thrown.

This PR adds a `sendAsync` method along with `*async` variations for all the shortcut methods (e.g. `getAsync`, `postAsync`, etc.). These all return a ColdBox `Future` instance.  Usage is as follows:

```cfc
var future = hyper.setUrl( "https://jsonplaceholder.typicode.com/posts/1" ).sendAsync();
var response = future.get(); // blocking until the request finishes.
var jsonBody = response.json();
```

Requests can be fire and forget:

```cfc
var future = hyper.postAsync( "https://jsonplaceholder.typicode.com/posts/", {
    "title": "My new post",
    "body": "Not much to see here",
    "userId": 1
} ).then( ( res ) => {
    systemOutput( "New post created: Post ID ###res.json().id#", true );
} ); 
```

And requests can be batched:

```cfc
var allPosts = variables.asyncManager.all( [
    hyper.getAsync( "https://jsonplaceholder.typicode.com/posts/1" ),
    hyper.getAsync( "https://jsonplaceholder.typicode.com/posts/2" ),
    hyper.getAsync( "https://jsonplaceholder.typicode.com/posts/3" )
] ).get(); // the get blocks until all posts are retrieved
```

None of the examples are unique to Hyper but rather are abilities gained from ColdBox `Future`s. The only things added in this PR is an easy way to create a ColdBox `Future` from a `HyperRequest`.