### PR TITLE
Fix Hyper Builder Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -898,17 +898,20 @@ component {
             .initWith(
                 baseUrl = "https://swapi.co/api"
             );
-
-        map( "GitHubClient" )
+    }
+    
+    function afterAspectsLoad(){
+		// Map Bindings below
+		map( "GitHubClient" )
             .to( "hyper.models.HyperBuilder" )
             .asSingleton()
             .initWith(
                 baseUrl = "https://api.github.com",
                 headers = {
-                    "Authorization" = getSetting( "SWAPI_TOKEN" )
+                    "Authorization" = getColdBox().getSetting( "SWAPI_TOKEN" )
                 }
             );
-    }
+	}
 
 }
 ```


### PR DESCRIPTION
Update the hyper client builder to use afterAspectsLoad and use the `getColdBox().getSetting()` so it doesn't error like the Merge Request we walked through together.