### PR TITLE
Update readme for builder initWith headers losing content-type

### DIFF
--- a/README.md
+++ b/README.md
@@ -908,13 +908,16 @@ component {
             .initWith(
                 baseUrl = "https://api.github.com",
                 headers = {
-                    "Authorization" = getColdBox().getSetting( "SWAPI_TOKEN" )
+                    "Content-Type" : "application/json", // If you map to a builder with headers - make sure you set your Content-Type if desired
+		    "Authorization" = getColdBox().getSetting( "SWAPI_TOKEN" )
                 }
             );
 	}
 
 }
 ```
+
+Note: If you are mapping a builder and use the `initWith( headers = {... } )`, these headers will overwrite the default headers you get with a HyperRequest so you might see some inconsistencies. A hyperRequest defaults the headers to `"Content-Type" : "application/json"`, so if you want to set a content-type, please include that in your headers struct, like above.
 
 You can also set or change the defaults by either passing the key / value pairs in to the `init` method or by calling the appropriate `HyperRequest` method on the `HyperBuilder.defaults` property.
 


### PR DESCRIPTION
Adding more documentation and a better default example of mapping to a builder by including the `"Content-Type" : "application/json"` header to avoid content type errors.