### PR TITLE
Handle when body is a string and format is JSON

### DIFF
--- a/models/HyperRequest.cfc
+++ b/models/HyperRequest.cfc
@@ -1071,6 +1071,9 @@ component accessors="true" {
 	 * @returns A simple value representing the body.
 	 */
 	public any function prepareBody() {
+		if ( isSimpleValue( getBody() ) ) {
+			return getBody();
+		}
 		return getBodyFormat() == "json" ? serializeJSON( getBody() ) : getBody();
 	}
 

--- a/tests/specs/unit/HyperRequestSpec.cfc
+++ b/tests/specs/unit/HyperRequestSpec.cfc
@@ -211,14 +211,14 @@ component extends="testbox.system.BaseSpec" {
 			} );
 
 			it( "can handle a JSON body format with a body as a string", function() {
-				req.setBodyFormat( 'json' );
+				req.setBodyFormat( "json" );
 				req.setBody( '{"query":{},"size":0,"from":0}' );
-				expect( req.prepareBody( ) ).toBe( '{"query":{},"size":0,"from":0}' );
+				expect( req.prepareBody() ).toBe( '{"query":{},"size":0,"from":0}' );
 			} );
 			it( "can handle a JSON body format with a body as an struct", function() {
-				req.setBodyFormat( 'json' );
-				req.setBody( {"query":{},"size":0,"from":0} );
-				expect( req.prepareBody( ) ).toBe( '{"query":{},"size":0,"from":0}' );
+				req.setBodyFormat( "json" );
+				req.setBody( { "query" : {}, "size" : 0, "from" : 0 } );
+				expect( req.prepareBody() ).toBe( '{"query":{},"size":0,"from":0}' );
 			} );
 		} );
 	}

--- a/tests/specs/unit/HyperRequestSpec.cfc
+++ b/tests/specs/unit/HyperRequestSpec.cfc
@@ -209,6 +209,17 @@ component extends="testbox.system.BaseSpec" {
 				expect( req.hasHeader( "X-Forwarded-For" ) ).toBeTrue();
 				expect( req.getHeader( "X-Forwarded-For" ) ).toBe( "1.1.1.1" );
 			} );
+
+			it( "can handle a JSON body format with a body as a string", function() {
+				req.setBodyFormat( 'json' );
+				req.setBody( '{"query":{},"size":0,"from":0}' );
+				expect( req.prepareBody( ) ).toBe( '{"query":{},"size":0,"from":0}' );
+			} );
+			it( "can handle a JSON body format with a body as an struct", function() {
+				req.setBodyFormat( 'json' );
+				req.setBody( {"query":{},"size":0,"from":0} );
+				expect( req.prepareBody( ) ).toBe( '{"query":{},"size":0,"from":0}' );
+			} );
 		} );
 	}
 


### PR DESCRIPTION
Prevent Hyper running serializeJSON against a string of JSON
This restores the previous behaviour changed in the following commit
4cc0eba6f9d0a9ab3bd33fa2ff2385b065b3815c