### PR TITLE
Update to facilitate sending XML content

### DIFF
--- a/models/CfhttpHttpClient.cfc
+++ b/models/CfhttpHttpClient.cfc
@@ -124,21 +124,57 @@ component implements="HyperHttpClientInterface" {
 
 		var cfhttpBody = [];
 		if ( req.hasBody() ) {
-			if ( req.getBodyFormat() == "json" ) {
-				cfhttpBody.append( req.prepareBody() );
-			} else if ( req.getBodyFormat() == "formFields" ) {
-				var body = req.getBody();
-				for ( var fieldName in body ) {
-					for ( var value in arrayWrap( body[ fieldName ] ) ) {
-						cfhttpBody.append( {
-							"type"  : "formfield",
-							"name"  : fieldName,
-							"value" : value
+			switch ( req.getBodyFormat() ) {
+				case "json":
+					if ( !headers.keyExists( "Content-Type" ) ) {
+						cfhttpHeaders.append( {
+							"name"  : "Content-Type",
+							"value" : "application/json"
 						} );
 					}
-				}
-			} else {
-				cfhttpBody.append( req.prepareBody() );
+
+					cfhttpBody.append( {
+						"type"  : "body",
+						"value" : req.prepareBody()
+					} );
+					break;
+				case "formFields":
+					if ( !headers.keyExists( "Content-Type" ) ) {
+						cfhttpHeaders.append( {
+							"name"  : "Content-Type",
+							"value" : "application/x-www-form-urlencoded"
+						} );
+					}
+
+					var body = req.getBody();
+					for ( var fieldName in body ) {
+						for ( var value in arrayWrap( body[ fieldName ] ) ) {
+							cfhttpBody.append( {
+								"type"  : "formfield",
+								"name"  : fieldName,
+								"value" : value
+							} );
+						}
+					}
+					break;
+				case "xml":
+					if ( !headers.keyExists( "Content-Type" ) ) {
+						cfhttpHeaders.append( {
+							"name"  : "Content-Type",
+							"value" : "application/xml"
+						} );
+					}
+
+					cfhttpBody.append( {
+						"type"  : "xml",
+						"value" : req.prepareBody()
+					} );
+					break;
+				default:
+					cfhttpBody.append( {
+						"type"  : "body",
+						"value" : req.prepareBody()
+					} );
 			}
 		}
 
@@ -242,21 +278,51 @@ component implements="HyperHttpClientInterface" {
 			}
 
 			if ( req.hasBody() ) {
-				if ( req.getBodyFormat() == "json" ) {
-					cfhttpparam( type = "body", value = req.prepareBody() );
-				} else if ( req.getBodyFormat() == "formFields" ) {
-					var body = req.getBody();
-					for ( var fieldName in body ) {
-						for ( var value in arrayWrap( body[ fieldName ] ) ) {
+				switch ( req.getBodyFormat() ) {
+					case "json":
+						if ( !headers.keyExists( "Content-Type" ) ) {
 							cfhttpparam(
-								type  = "formfield",
-								name  = fieldName,
-								value = value
+								type  = "header",
+								name  = "Content-Type",
+								value = "application/json"
 							);
 						}
-					}
-				} else {
-					cfhttpparam( type = "body", value = req.prepareBody() );
+
+						cfhttpparam( type = "body", value = req.prepareBody() );
+						break;
+					case "formFields":
+						if ( !headers.keyExists( "Content-Type" ) ) {
+							cfhttpparam(
+								type  = "header",
+								name  = "Content-Type",
+								value = "application/x-www-form-urlencoded"
+							);
+						}
+
+						var body = req.getBody();
+						for ( var fieldName in body ) {
+							for ( var value in arrayWrap( body[ fieldName ] ) ) {
+								cfhttpparam(
+									type  = "formfield",
+									name  = fieldName,
+									value = value
+								);
+							}
+						}
+						break;
+					case "xml":
+						if ( !headers.keyExists( "Content-Type" ) ) {
+							cfhttpparam(
+								type  = "header",
+								name  = "Content-Type",
+								value = "application/xml"
+							);
+						}
+
+						cfhttpparam( type = "xml", value = req.prepareBody() );
+						break;
+					default:
+						cfhttpparam( type = "body", value = req.prepareBody() );
 				}
 			}
 		}

--- a/models/CfhttpHttpClient.cfc
+++ b/models/CfhttpHttpClient.cfc
@@ -126,6 +126,7 @@ component implements="HyperHttpClientInterface" {
 		if ( req.hasBody() ) {
 			switch ( req.getBodyFormat() ) {
 				case "json":
+					// this is here for backwards compatibility
 					if ( !headers.keyExists( "Content-Type" ) ) {
 						cfhttpHeaders.append( {
 							"name"  : "Content-Type",
@@ -138,14 +139,8 @@ component implements="HyperHttpClientInterface" {
 						"value" : req.prepareBody()
 					} );
 					break;
-				case "formFields":
-					if ( !headers.keyExists( "Content-Type" ) ) {
-						cfhttpHeaders.append( {
-							"name"  : "Content-Type",
-							"value" : "application/x-www-form-urlencoded"
-						} );
-					}
 
+				case "formFields":
 					var body = req.getBody();
 					for ( var fieldName in body ) {
 						for ( var value in arrayWrap( body[ fieldName ] ) ) {
@@ -157,19 +152,14 @@ component implements="HyperHttpClientInterface" {
 						}
 					}
 					break;
-				case "xml":
-					if ( !headers.keyExists( "Content-Type" ) ) {
-						cfhttpHeaders.append( {
-							"name"  : "Content-Type",
-							"value" : "application/xml"
-						} );
-					}
 
+				case "xml":
 					cfhttpBody.append( {
 						"type"  : "xml",
 						"value" : req.prepareBody()
 					} );
 					break;
+
 				default:
 					cfhttpBody.append( {
 						"type"  : "body",
@@ -280,6 +270,7 @@ component implements="HyperHttpClientInterface" {
 			if ( req.hasBody() ) {
 				switch ( req.getBodyFormat() ) {
 					case "json":
+						// this is here for backwards compatibility
 						if ( !headers.keyExists( "Content-Type" ) ) {
 							cfhttpparam(
 								type  = "header",
@@ -290,15 +281,8 @@ component implements="HyperHttpClientInterface" {
 
 						cfhttpparam( type = "body", value = req.prepareBody() );
 						break;
-					case "formFields":
-						if ( !headers.keyExists( "Content-Type" ) ) {
-							cfhttpparam(
-								type  = "header",
-								name  = "Content-Type",
-								value = "application/x-www-form-urlencoded"
-							);
-						}
 
+					case "formFields":
 						var body = req.getBody();
 						for ( var fieldName in body ) {
 							for ( var value in arrayWrap( body[ fieldName ] ) ) {
@@ -310,17 +294,11 @@ component implements="HyperHttpClientInterface" {
 							}
 						}
 						break;
-					case "xml":
-						if ( !headers.keyExists( "Content-Type" ) ) {
-							cfhttpparam(
-								type  = "header",
-								name  = "Content-Type",
-								value = "application/xml"
-							);
-						}
 
+					case "xml":
 						cfhttpparam( type = "xml", value = req.prepareBody() );
 						break;
+
 					default:
 						cfhttpparam( type = "body", value = req.prepareBody() );
 				}

--- a/models/HyperRequest.cfc
+++ b/models/HyperRequest.cfc
@@ -159,7 +159,6 @@ component accessors="true" {
 		variables.httpClient  = arguments.httpClient;
 		variables.queryParams = [];
 		variables.headers     = createObject( "java", "java.util.LinkedHashMap" ).init();
-		variables.headers.put( "Content-Type", "application/json" );
 		variables.files              = [];
 		variables.requestCallbacks   = [];
 		variables.responseCallbacks  = [];
@@ -738,6 +737,17 @@ component accessors="true" {
 	}
 
 	/**
+	 * A convenience method to set the body format and Content-Type to xml.
+	 *
+	 * @returns The HyperRequest instance.
+	 */
+	function asXML() {
+		setBodyFormat( "xml" );
+		setContentType( "application/xml" );
+		return this;
+	}
+
+	/**
 	 * Attaches a file to the Hyper request.
 	 * Also sets the Content-Type as `multipart/form-data`.
 	 * Multiple files can be attached by calling `attach` multiple times before calling a send method.
@@ -901,7 +911,6 @@ component accessors="true" {
 		setReferrer( javacast( "null", "" ) );
 		variables.queryParams = [];
 		variables.headers     = createObject( "java", "java.util.LinkedHashMap" ).init();
-		variables.headers.put( "Content-Type", "application/json" );
 		variables.files             = [];
 		variables.requestCallbacks  = [];
 		variables.responseCallbacks = [];

--- a/tests/specs/integration/DebugSpec.cfc
+++ b/tests/specs/integration/DebugSpec.cfc
@@ -35,7 +35,7 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 				expect( debugReq.body ).toHaveKey( "body" );
 				expect( debugReq.body.body ).toBeArray();
 				expect( debugReq.body.body ).toHaveLength( 1 );
-				expect( debugReq.body.body[ 1 ] ).toBe( binaryBody );
+				expect( debugReq.body.body[ 1 ] ).toBe( { "type": "body", "value": binaryBody } );
 				expect( debugReq.body ).toHaveKey( "files" );
 				expect( debugReq.body.files ).toBeEmpty();
 

--- a/tests/specs/unit/HyperRequestSpec.cfc
+++ b/tests/specs/unit/HyperRequestSpec.cfc
@@ -162,6 +162,7 @@ component extends="testbox.system.BaseSpec" {
 				} );
 
 				req.withHeaders( { "Accept" : "application/xml" } )
+					.asJSON()
 					.patch( "https://jsonplaceholder.typicode.com/posts/1" );
 				expect( method ).toBe( "PATCH" );
 				expect( headers ).toBe( {


### PR DESCRIPTION
Issue: currently, Hyper always sets/sends a content-type header of 'application/json' by default which is not always accurate.  We need to be able to send XML data with or without the content-type header being specified.

Changes:
* Removed the default content-type header that was set upon request init
* Added the default content-type header of 'application/json' if the request body type is 'json'
* Added another option for the request body type of 'xml' which treats the body content as XML
* Added helper function asXML() that sets both the content-type header and request body type for an XML request