### PR TITLE
Lucee 6 compat updates

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        cfengine: ["lucee@5", "adobe@2018", "adobe@2021", "adobe@2023", "boxlang@be"]
+        cfengine: ["lucee@5", "lucee@6", "adobe@2018", "adobe@2021", "adobe@2023", "boxlang@be"]
         coldbox: ["coldbox@6", "coldbox@7"]
     steps:
       - name: Checkout Repository
@@ -28,7 +28,7 @@ jobs:
       - name: Install dependencies
         run: |
           box install
-          box install ${{ matrix.coldbox }} --noSave
+          box install ${{ matrix.coldbox }} --force --noSave
 
       - name: Start server
         run: |

--- a/models/HyperBuilder.cfc
+++ b/models/HyperBuilder.cfc
@@ -76,7 +76,7 @@ component singleton {
 	 * @returns A new HyperRequest instance from the default request.
 	 */
 	public HyperRequest function new() {
-		var req = this.defaults.clone();
+		var req = this.defaults.duplicate();
 		req.setBuilder( this );
 		if ( !isNull( variables.fakeConfiguration ) ) {
 			req.setFakeConfiguration( variables.fakeConfiguration );

--- a/models/HyperRequest.cfc
+++ b/models/HyperRequest.cfc
@@ -1283,7 +1283,7 @@ component accessors="true" {
 		req.setBody( duplicate( variables.body ) );
 		req.setBodyFormat( variables.bodyFormat );
 		req.setReferrer( isNull( variables.referrer ) ? javacast( "null", "" ) : variables.referrer );
-		req.setHeaders( variables.headers.clone() );
+		req.setHeaders( variables.headers.duplicate() );
 		req.setQueryParams( duplicate( variables.queryParams ) );
 		req.setFiles( duplicate( variables.files ) );
 		req.setThrowOnError( variables.throwOnError );


### PR DESCRIPTION
- The member function `.clone` on a Struct is undocumented and is not available in Lucee 6.  `.duplicate` is available on all engines
- Adds Lucee 6 to matrix